### PR TITLE
VMware HPET fix

### DIFF
--- a/os/init_64.asm
+++ b/os/init_64.asm
@@ -224,8 +224,8 @@ no_more_aps:
 	bts rax, 6			; Tn_VAL_SET_CNF
 	mov [rsi+0x100], rax
 
-	xor eax, eax
-	mov [rsi+0x108], rax		; Clear the Timer 0 Comparator Register
+	mov rax, 0xFFFFFFFFFFFFFFFF	; Set the Timer 0 Comparator Register
+	mov [rsi+0x108], rax
 
 	mov rax, [rsi+0x10]		; General Configuration Register
 	bts rax, 0			; ENABLE_CNF - Enable the HPET
@@ -243,7 +243,7 @@ ret
 create_gate:
 	push rdi
 	push rax
-	
+
 	shl rdi, 4	; quickly multiply rdi by 16
 	stosw		; store the low word (15..0)
 	shr rax, 16
@@ -260,7 +260,7 @@ ret
 init_memory_map:	; Build the OS memory table
 	push rax
 	push rcx
-	push rdi 
+	push rdi
 
 	; Build a fresh memory map for the system
 	mov rdi, os_MemoryMap
@@ -305,7 +305,7 @@ ret
 ; -----------------------------------------------------------------------------
 ; ioapic_reg_write -- Write to an I/O APIC register
 ;  IN:	EAX = Value to write
-;	ECX = Index of register 
+;	ECX = Index of register
 ; OUT:	Nothing. All registers preserved
 ioapic_reg_write:
 	push rsi


### PR DESCRIPTION
Set HPET Timer 0 Comparator Register to a high value, since setting it to 0 freezes VMware.

This appears to be because according to the General Behavioural Rules of Section 2.3.9.1 of the IA-PC HPET Specification, every time the main counter equals the value in the comparator register, an interrupt is triggered and the value in the comparator register is increased by the last value written to it. VMware's emulation does not appear to sanity-check the value, presumably putting it into an infinite loop.
