### PR TITLE
add newline after input in os_input

### DIFF
--- a/os/cli.asm
+++ b/os/cli.asm
@@ -21,7 +21,6 @@ os_command_line:
 	mov rdi, cli_temp_string
 	mov rcx, 250			; Limit the input to 250 characters
 	call os_input
-	call os_print_newline		; The user hit enter so print a new line
 	jrcxz os_command_line		; os_input_string stores the number of characters received in RCX
 
 	mov rsi, rdi

--- a/os/syscalls/input.asm
+++ b/os/syscalls/input.asm
@@ -62,6 +62,7 @@ os_input_halt:
 	jmp os_input_more
 
 os_input_done:	
+	call os_print_newline
 	mov al, 0x00
 	stosb				; We NULL terminate the string
 	mov al, ' '


### PR DESCRIPTION
print the newline after it was detected, this mirrors the behaviour i'd expect from a shell more closely
